### PR TITLE
add callfor papers menu and en, pt, es pages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,6 +58,31 @@ const menuItems = [
       },
     ],
   },
+    {
+    "label:en": "Call for papers",
+    "label:es": "Call for papers",
+    "label:pt": "Call for papers",
+    links: [
+      {
+        "label:en": "General program",
+        "label:es": "General program",
+        "label:pt": "General program",
+        href: "/general-cfp",
+      },
+      {
+        "label:en": "Workshop program",
+        "label:es": "Workshop program",
+        "label:pt": "Workshop program",
+        href: "/workshop-cfp",
+      },
+      {
+        "label:en": "Academic program",
+        "label:es": "Academic program",
+        "label:pt": "Academic program",
+        href: "/academic-cfp",
+      },
+    ],
+   },
   {
     "label:en": "Map",
     "label:es": "Mapa",

--- a/src/pages/en/academic-cfp.mdx
+++ b/src/pages/en/academic-cfp.mdx
@@ -1,0 +1,32 @@
+import MdxLayout from "@/components/MDXLayout";
+
+export const metadata = {
+  title: "Call For Papers",
+  description: null,
+  image: null,
+};
+
+<br />
+
+# FOSS4G 2024 Academic Track
+
+Following an established tradition, FOSS4G organizes an Academic Track which will run over the days of the Conference. The Scientific Committee of FOSS4G 2023 invites original research contributions addressing any topic or domain connected to Open Source Geospatial Software, including (but not limited to) Open Hardware, Open software development, Open GIScience, Open Geospatial Data, (Geo)Spatial Data Sharing Systems, Open (Geospatial) Cloud Platforms and Services, Open (Geo)Education, Participatory Mapping, Digital Twins, GeoAI and Geospatial Machine Learning.
+
+All types of papers are welcome, including on results achieved, case studies, work in progress, reviews and demos. We discourage, however, mere presentations of technology or use cases without properly justifying originality against the scientific state of the art and without particular novelty. In addition, the use of open source geospatial software should be properly highlighted. Contributions from PhD students and early-stage researchers are particularly encouraged.
+
+In the evaluation of proposals, the Scientific Committee will pay particular attention to the reproducibility of the research (where this is applicable). Reproducibility is ensured when the research makes all artefacts (input data, computational steps, methods and code) openly available to obtain consistent results. When available, the code shall be publicly released under an open source license.
+
+Please check the full Call for papers available on the [FOSS4G 2024 website](https://2024.foss4g.org/call-for-papers/academic-cfp/).
+
+export default function MDXPage({ children }) {
+  return <MdxLayout metadata={metadata}>{children}</MdxLayout>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      metadata
+    },
+  }
+
+}

--- a/src/pages/en/general-cfp.mdx
+++ b/src/pages/en/general-cfp.mdx
@@ -1,0 +1,91 @@
+import MdxLayout from "@/components/MDXLayout";
+
+export const metadata = {
+  title: "Call For Papers",
+  description: null,
+  image: null,
+};
+
+<br />
+
+# General Track FOSS4G 2024
+
+The aim of the conference is twofold: the exchange of information and experiences between users of geographic data and Free and Open Source software for processing geographic information and the possibility for new or potential users to discover the functionality of these systems and the availability of data, and to meet developers and experienced users.
+
+Talks are expected to share experiences using or developing free geographic data and metadata and using or developing free and open-source geographic software. Your contribution could present all about how you use open-source geospatial software, how it helps to solve your company/organization problems, a new development you are involved in, what it has improved, etc., in the various application fields.
+
+Submissions promoting restricted licensed software will not be accepted. This is a Free Open Source Software conference, and FOSS is the main interest.
+
+# How to Submit a Proposal
+
+You will have to submit your proposal (up to 1000 words) when submitting a talk. Then, you will be asked to select a general Track that best defines your contribution:
+
+-   State of Software;
+-   Transition to FOSS4G;
+-   Use cases & applications;
+-   Education;
+-   Open data;
+-   Community & Foundation
+-   AI4EO Challenges & Opportunities
+-   Open Standard
+-   Applications and solutions for the Amazon region
+
+A special track is also available:
+
+-   Open source geospatial “Made in Latin America.”
+
+You will also have to select one general Theme that best defines your proposal:
+
+-   Software status/state of the art, new software/project development, benchmarking;
+-   FOSS4G implementations in strategic application domains: land management, crisis/disaster response, smart cities, population mapping, climate change, ocean and marine monitoring, etc.;
+-   Data visualization: spatial analysis, manipulation, and visualization of geospatial data;
+-   Data collection, data sharing, data science, open data, big data, and data exploitation platforms;
+-   Sensors and data processing: remote sensing, lidar, structure from motion, and GNSS;
+-   New trends: IoT, Indoor mapping, drones - UAV (uncrewed aerial vehicle), Urban Digital Twins, Artificial intelligence - machine learning, deep learning, geospatial data structures, real-time raster analysis;
+-   Open and reproducible science;
+-   Standards, interoperability, SDIs, metadata, and INSPIRE implementations;
+-   Community & participatory FOSS4G;
+-   FOSS4G at governmental institutions;
+-   FOSS4G in education;
+-   FOSS4G for Sustainable Development Goals (SDG);
+-   FOSS4G for Public Health;
+-   Business products powered by FOSS4G;
+
+
+Next, you will assign a number between 1 and 4, indicating your contribution's technical complexity level. One means that the audience can have minimal technical knowledge related to your submission’s subject to understand it, and four means that your audience must be highly technical to get the most out of your talk.
+
+Furthermore, you are encouraged to indicate resources (video, web pages, papers, etc.) to read in advance, which will help you get up to speed on advanced topics.
+
+If you are interested in organizing another particular track, sponsor the event!
+
+Look at the sponsorship page for additional information.
+
+# Guidelines for Submissions
+
+OSGeo is an open, grassroots, dynamic community whose flagship event has inherited its profound characteristics. There are no formal indications when preparing your contribution for FOSS4G, yet please consider the following suggestions:
+
+-   FOSS4G’s backbone is open source, so make sure you indicate what is (are) the open source project(s) essential in your talk;
+-   If discussing new developments or a new open-source project, please point to its repository(ies). You’ll speak in a room full of geeks with computers and high-speed internet.
+-   The more suitable the selections of topic, theme, and level of technical complexity are, the better shaped the final program will be. So, please help us optimize your time at FOSS4G 2024.
+-   We believe in equality, so all presenters have the same amount of time to present their work – 20 minutes for the talk, 5 for Q&A, and 5 for changing rooms. Please consider that when preparing your slides.
+-   Last but not least, the success of this event lies in the responsible actions of all participants and organizers alike. If you or the co-authors can no longer be present after you have confirmed participation, please let us know as soon as possible.
+
+
+# Contribution selection process
+
+FOSS4G is an event for the international geospatial community. Thus, the primary selection of talks will be done through the open community voting process. The program automatically includes the highest-scored ones, while the FOSS4G 2024 Belém volunteer Program Committee will review the others.
+
+We will make sure that the conference program will be well-balanced and diverse. Moreover, the Program Committee will work hard to ensure that every OSGeo project has its proper representation. If you are part of some FOSS4G project and want to propose a special session, contact us to ensure we consider the proposal carefully.
+
+export default function MDXPage({ children }) {
+  return <MdxLayout metadata={metadata}>{children}</MdxLayout>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      metadata
+    },
+  }
+
+}

--- a/src/pages/es/academic-cfp.mdx
+++ b/src/pages/es/academic-cfp.mdx
@@ -1,0 +1,32 @@
+import MdxLayout from "@/components/MDXLayout";
+
+export const metadata = {
+  title: "Call For Papers",
+  description: null,
+  image: null,
+};
+
+<br />
+
+# FOSS4G 2024 Academic Track
+
+Siguiendo una tradición establecida, FOSS4G organiza un Tema Académico que se desarrollará durante los días de la Conferencia. El Comité Científico de FOSS4G 2023 invita a contribuciones de investigación originales que aborden cualquier tema o dominio relacionado con el Software Geoespacial de Código Abierto, incluyendo (pero no limitado a) Hardware Abierto, Desarrollo de Software Abierto, GISciencia Abierta, Datos Geoespaciales Abiertos, Sistemas de Intercambio de Datos (Geo)Espaciales, Plataformas y Servicios en Nube (Geoespaciales) Abiertos, (Geo)Educación Abierta, Cartografía Participativa, Gemelos Digitales, GeoAI y Aprendizaje Automático Geoespacial.
+
+Todos los tipos de ponencias son bienvenidos, incluidos los resultados obtenidos, estudios de casos, trabajos en curso, revisiones y demostraciones. Desaconsejamos, sin embargo, las meras presentaciones de tecnología o casos de uso sin justificar adecuadamente la originalidad frente al estado del arte científico y sin especial novedad. Además, debe destacarse adecuadamente el uso de software geoespacial de código abierto. Se alientan especialmente las contribuciones de estudiantes de doctorado e investigadores en fase inicial.
+
+En la evaluación de las propuestas, el Comité Científico prestará especial atención a la reproducibilidad de la investigación (cuando proceda). La reproducibilidad queda garantizada cuando la investigación pone a disposición del público todos los artefactos (datos de entrada, pasos computacionales, métodos y código) para obtener resultados coherentes. Cuando esté disponible, el código se hará público bajo una licencia de código abierto.
+
+Consulte la convocatoria de ponencias completa disponible en el [sitio web de FOSS4G 2024](https://2024.foss4g.org/call-for-papers/academic-cfp/).
+
+export default function MDXPage({ children }) {
+  return <MdxLayout metadata={metadata}>{children}</MdxLayout>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      metadata
+    },
+  }
+
+}

--- a/src/pages/es/general-cfp.mdx
+++ b/src/pages/es/general-cfp.mdx
@@ -1,0 +1,90 @@
+import MdxLayout from "@/components/MDXLayout";
+
+export const metadata = {
+  title: "Call For Papers",
+  description: null,
+  image: null,
+};
+
+<br />
+
+# General Track FOSS4G 2024
+
+El objetivo de la conferencia es doble: el intercambio de información y experiencias entre usuarios de datos geográficos y software libre y de código abierto para el tratamiento de información geográfica y la posibilidad de que usuarios nuevos o potenciales descubran la funcionalidad de estos sistemas y la disponibilidad de datos, y conozcan a desarrolladores y usuarios experimentados.
+
+Se espera que las ponencias compartan experiencias de uso o desarrollo de datos y metadatos geográficos libres y de uso o desarrollo de software geográfico libre y de código abierto. Su contribución podría versar sobre cómo utiliza el software geoespacial de código abierto, cómo le permite resolver los problemas de su empresa/organización, un nuevo desarrollo en el que esté implicado, qué ha mejorado, etc., en los distintos campos de aplicación.
+
+No se aceptarán presentaciones que promocionen software con licencia restringida. Esta es una conferencia de Software Libre de Código Abierto, y el FOSS es el principal interés.
+
+# Cómo presentar una propuesta
+
+Tendrá que presentar su propuesta (de hasta 1000 palabras) al presentar una ponencia. A continuación, se le pedirá que seleccione un Tema general que defina mejor su contribución:
+
+- Estado del software;
+- Transición a FOSS4G;
+- Casos de uso y aplicaciones;
+- Educación;
+- Datos abiertos;
+- Comunidad y Fundación
+- Retos y oportunidades de AI4EO
+- Estándar abierto
+- Aplicaciones y soluciones para la región amazónica
+
+También está disponible un track especial
+
+- Geoespacial de código abierto «Hecho en América Latina».
+
+También deberá seleccionar un Tema general que defina mejor su propuesta:
+- Estado del software/estado del arte, desarrollo de nuevo software/proyectos, evaluación comparativa;
+- Implementaciones de FOSS4G en ámbitos de aplicación estratégicos: gestión del territorio, respuesta a crisis/catástrofes, ciudades inteligentes, cartografía de la población, cambio climático, vigilancia oceánica y marina, etc;
+- Visualización de datos: análisis espacial, manipulación y visualización de datos geoespaciales;
+- Recopilación de datos, intercambio de datos, ciencia de datos, datos abiertos, big data y plataformas de explotación de datos;
+- Sensores y procesamiento de datos: teledetección, lidar, estructura a partir del movimiento y GNSS;
+- Nuevas tendencias: IoT, Cartografía en interiores, drones - UAV (vehículo aéreo no tripulado), Gemelos digitales urbanos, Inteligencia artificial - aprendizaje automático, aprendizaje profundo, estructuras de datos geoespaciales, análisis ráster en tiempo real;
+- Ciencia abierta y reproducible;
+- Estándares, interoperabilidad, IDE, metadatos e implementaciones INSPIRE;
+- FOSS4G comunitario y participativo;
+- FOSS4G en instituciones gubernamentales;
+- FOSS4G en la educación;
+- FOSS4G para los Objetivos de Desarrollo Sostenible (ODS);
+- FOSS4G para la salud pública;
+- Productos empresariales impulsados por FOSS4G;
+
+
+A continuación, asignará un número entre 1 y 4, que indicará el nivel de complejidad técnica de su contribución. Uno significa que la audiencia puede tener unos conocimientos técnicos mínimos relacionados con el tema de su presentación para entenderla, y cuatro significa que su audiencia debe ser muy técnica para sacar el máximo partido de su charla.
+
+Además, le animamos a que indique recursos (vídeos, páginas web, artículos, etc.) para leer con antelación, lo que le ayudará a ponerse al día en temas avanzados.
+
+Si está interesado en organizar otro tema en particular, ¡patrocine el evento!
+
+Consulte la página de patrocinio para más información.
+
+# Directrices para la presentación de propuestas
+
+OSGeo es una comunidad abierta, de base y dinámica cuyo evento insignia ha heredado sus profundas características. No hay indicaciones formales a la hora de preparar su contribución para FOSS4G, pero tenga en cuenta las siguientes sugerencias:
+
+- La columna vertebral de FOSS4G es el código abierto, así que asegúrese de indicar cuál o cuáles son los proyectos de código abierto esenciales en su charla;
+- Si habla de nuevos desarrollos o de un nuevo proyecto de código abierto, señale su(s) repositorio(s). Hablarás en una sala llena de frikis con ordenadores e internet de alta velocidad.
+- Cuanto más adecuadas sean las selecciones de tema, asunto y nivel de complejidad técnica, mejor conformado estará el programa final. Así que, por favor, ayúdenos a optimizar su tiempo en FOSS4G 2024.
+- Creemos en la igualdad, por lo que todos los ponentes disponen del mismo tiempo para presentar su trabajo: 20 minutos para la charla, 5 para las preguntas y respuestas, y 5 para los vestuarios. Por favor, téngalo en cuenta a la hora de preparar sus diapositivas.
+- Por último, pero no por ello menos importante, el éxito de este evento radica en la actuación responsable de todos los participantes y organizadores. Si usted o los coautores no pueden estar presentes después de haber confirmado su participación, le rogamos que nos lo comunique lo antes posible.
+
+
+# Proceso de selección de contribuciones
+
+FOSS4G es un evento para la comunidad geoespacial internacional. Por lo tanto, la selección primaria de las ponencias se hará a través del proceso de votación abierta de la comunidad. El programa incluirá automáticamente las más votadas, mientras que el Comité de Programa voluntario de FOSS4G 2024 Belém revisará las demás.
+
+Nos aseguraremos de que el programa de la conferencia sea equilibrado y diverso. Además, el Comité de Programa trabajará duro para asegurar que cada proyecto OSGeo tenga su representación adecuada. Si formas parte de algún proyecto FOSS4G y quieres proponer una sesión especial, ponte en contacto con nosotros para asegurarte de que consideramos la propuesta cuidadosamente.
+
+export default function MDXPage({ children }) {
+  return <MdxLayout metadata={metadata}>{children}</MdxLayout>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      metadata
+    },
+  }
+
+}

--- a/src/pages/pt/academic-cfp.mdx
+++ b/src/pages/pt/academic-cfp.mdx
@@ -1,0 +1,32 @@
+import MdxLayout from "@/components/MDXLayout";
+
+export const metadata = {
+  title: "Call For Papers",
+  description: null,
+  image: null,
+};
+
+<br />
+
+# FOSS4G 2024 Academic Track
+
+Seguindo uma tradição estabelecida, o FOSS4G organiza uma trilha acadêmica que será realizada durante os dias da Conferência. O Comitê Científico do FOSS4G 2023 convida contribuições originais de pesquisa que abordem qualquer tópico ou domínio relacionado ao Software Geoespacial de Código Aberto, incluindo (mas não se limitando a) Hardware Aberto, Desenvolvimento de Software Aberto, Ciência SIG Aberta, Dados Geoespaciais Abertos, Sistemas de Compartilhamento de Dados (Geo)Espaciais, Plataformas e Serviços de Nuvem Abertos (Geoespaciais), Educação (Geo)Aberta, Mapeamento Participativo, Gêmeos Digitais, GeoAI e Aprendizado de Máquina Geoespacial.
+
+Todos os tipos de artigos são bem-vindos, incluindo os resultados alcançados, estudos de caso, trabalhos em andamento, revisões e demonstrações. No entanto, não recomendamos meras apresentações de tecnologia ou casos de uso sem justificar adequadamente a originalidade em relação ao estado da arte científica e sem novidades específicas. Além disso, o uso de software geoespacial de código aberto deve ser devidamente destacado. As contribuições de estudantes de doutorado e pesquisadores em estágio inicial são especialmente incentivadas.
+
+Na avaliação das propostas, o Comitê Científico dará atenção especial à reprodutibilidade da pesquisa (quando aplicável). A reprodutibilidade é garantida quando a pesquisa disponibiliza abertamente todos os artefatos (dados de entrada, etapas computacionais, métodos e código) para obter resultados consistentes. Quando disponível, o código deve ser liberado publicamente sob uma licença de código aberto.
+
+Consulte a Chamada de trabalhos completa disponível no [site do FOSS4G 2024] (https://2024.foss4g.org/call-for-papers/academic-cfp/).
+
+export default function MDXPage({ children }) {
+  return <MdxLayout metadata={metadata}>{children}</MdxLayout>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      metadata
+    },
+  }
+
+}

--- a/src/pages/pt/general-cfp.mdx
+++ b/src/pages/pt/general-cfp.mdx
@@ -1,0 +1,91 @@
+import MdxLayout from "@/components/MDXLayout";
+
+export const metadata = {
+  title: "Call For Papers",
+  description: null,
+  image: null,
+};
+
+<br />
+
+# General Track FOSS4G 2024
+
+O objetivo da conferência é duplo: a troca de informações e experiências entre usuários de dados geográficos e de software livre e de código aberto para o processamento de informações geográficas e a possibilidade de usuários novos ou em potencial descobrirem a funcionalidade desses sistemas e a disponibilidade de dados, além de conhecerem desenvolvedores e usuários experientes.
+
+Espera-se que as palestras compartilhem experiências de uso ou desenvolvimento de dados e metadados geográficos gratuitos e de uso ou desenvolvimento de software geográfico gratuito e de código aberto. Sua contribuição pode apresentar tudo sobre como você usa software geoespacial de código aberto, como ele ajuda a resolver os problemas de sua empresa/organização, um novo desenvolvimento no qual você está envolvido, o que ele melhorou, etc., nos vários campos de aplicação.
+
+Não serão aceitos envios que promovam softwares com licenças restritas. Esta é uma conferência sobre software livre de código aberto, e o FOSS é o principal interesse.
+
+# Como enviar uma proposta
+
+Você terá que enviar sua proposta (até 1000 palavras) ao enviar uma palestra. Em seguida, será solicitado que você selecione uma trilha geral que melhor defina sua contribuição:
+
+- Estado do software;
+- Transição para o FOSS4G;
+- Casos de uso e aplicativos;
+- Educação;
+- Dados abertos;
+- Comunidade e fundação
+- Desafios e oportunidades do AI4EO
+- Padrão aberto
+- Aplicativos e soluções para a região amazônica
+
+Uma trilha especial também está disponível:
+
+- Geoespacial de código aberto “Made in Latin America”.
+
+
+Você também terá que selecionar um tema geral que melhor defina sua proposta:
+
+- Status/estado da arte do software, desenvolvimento de novos softwares/projetos, benchmarking;
+- Implementações do FOSS4G em domínios de aplicativos estratégicos: gerenciamento de terras, resposta a crises/desastres, cidades inteligentes, mapeamento populacional, mudança climática, monitoramento marinho e oceânico, etc;
+- Visualização de dados: análise espacial, manipulação e visualização de dados geoespaciais;
+- Coleta de dados, compartilhamento de dados, ciência de dados, dados abertos, big data e plataformas de exploração de dados;
+- Sensores e processamento de dados: sensoriamento remoto, lidar, estrutura de movimento e GNSS;
+- Novas tendências: IoT, mapeamento interno, drones - UAV (veículo aéreo não tripulado), gêmeos digitais urbanos, inteligência artificial - aprendizado de máquina, aprendizado profundo, estruturas de dados geoespaciais, análise raster em tempo real;
+- Ciência aberta e reproduzível;
+- Padrões, interoperabilidade, SDIs, metadados e implementações INSPIRE;
+- FOSS4G comunitário e participativo;
+- FOSS4G em instituições governamentais;
+- FOSS4G na educação;
+- FOSS4G para os Objetivos de Desenvolvimento Sustentável (SDG);
+- FOSS4G para a saúde pública;
+- Produtos comerciais alimentados pelo FOSS4G;
+
+Em seguida, você atribuirá um número entre 1 e 4, indicando o nível de complexidade técnica da sua contribuição. Um significa que o público pode ter um conhecimento técnico mínimo relacionado ao assunto da sua apresentação para entendê-la, e quatro significa que o público deve ser altamente técnico para aproveitar ao máximo a sua palestra.
+
+Além disso, recomendamos que você indique recursos (vídeos, páginas da Web, artigos etc.) para ler com antecedência, o que o ajudará a se atualizar sobre tópicos avançados.
+
+Se você estiver interessado em organizar outra trilha específica, patrocine o evento!
+
+Consulte a página de patrocínio para obter mais informações.
+
+# Diretrizes para envio de trabalhos
+
+A OSGeo é uma comunidade aberta, de base e dinâmica, cujo principal evento herdou suas características profundas. Não há indicações formais ao preparar sua contribuição para o FOSS4G, mas considere as sugestões a seguir:
+
+- A espinha dorsal do FOSS4G é o código-fonte aberto, portanto, certifique-se de indicar qual(is) é(são) o(s) projeto(s) de código-fonte aberto essencial(is) em sua palestra;
+- Se estiver discutindo novos desenvolvimentos ou um novo projeto de código aberto, indique o(s) respectivo(s) repositório(s). Você falará em uma sala cheia de geeks com computadores e Internet de alta velocidade.
+- Quanto mais adequadas forem as seleções de tópico, tema e nível de complexidade técnica, melhor será o formato do programa final. Portanto, ajude-nos a otimizar seu tempo no FOSS4G 2024.
+- Acreditamos na igualdade, portanto, todos os apresentadores têm o mesmo tempo para apresentar seu trabalho - 20 minutos para a palestra, 5 para perguntas e respostas e 5 para os vestiários. Leve isso em consideração ao preparar seus slides.
+- Por último, mas não menos importante, o sucesso desse evento depende das ações responsáveis de todos os participantes e organizadores. Se você ou os coautores não puderem mais estar presentes após a confirmação da participação, informe-nos o mais rápido possível.
+
+
+# Processo de seleção de contribuições
+
+O FOSS4G é um evento para a comunidade geoespacial internacional. Portanto, a seleção primária das palestras será feita por meio do processo aberto de votação da comunidade. O programa inclui automaticamente as palestras mais bem pontuadas, enquanto o Comitê de Programa voluntário do FOSS4G 2024 Belém analisará as demais.
+
+Garantiremos que o programa da conferência seja bem equilibrado e diversificado. Além disso, o Comitê de Programa trabalhará arduamente para garantir que cada projeto OSGeo tenha sua representação adequada. Se você faz parte de algum projeto FOSS4G e deseja propor uma sessão especial, entre em contato conosco para garantir que a proposta seja considerada com cuidado.
+
+export default function MDXPage({ children }) {
+  return <MdxLayout metadata={metadata}>{children}</MdxLayout>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      metadata
+    },
+  }
+
+}


### PR DESCRIPTION
Hey @rami-dv .
took some time to help in this task. This PR still as draft.
I have:
- [X] Added "Call for papers" in  main menu;
- [X] Added "General track", "Workshop track" and "Academic track" as subitenms;
- [X] Created page for `en`, `es`, and `pt` for 
  - [X] "General track";
  - [X] "Workshop track"

What is missing:
Create page for `en`, `es`, and `pt` for : 
  - [ ] "Academic track";
  - [ ] Add buttom to all pages linkin to pretalks CFP;